### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Lint and Test (Node ${{ matrix.node-version }})


### PR DESCRIPTION
Potential fix for [https://github.com/hirakinii/osf-api-v2-typescript/security/code-scanning/1](https://github.com/hirakinii/osf-api-v2-typescript/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root (top-level) so it applies to all jobs by default. The minimal least-privilege setting for this workflow is:

- `contents: read`

This is sufficient for `actions/checkout` and typical read-only CI tasks (install, lint, test, build).  
Best single change: insert the `permissions` block after the `on:` triggers (or before `jobs:`) and keep job logic unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
